### PR TITLE
Fix float convert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
-module github.com/g3kk0/go-forex
+module github.com/daesu/go-forex
+
+go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/daesu/go-forex
+module github.com/g3kk0/go-forex
 
 go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/g3kk0/go-forex
-
-go 1.15

--- a/helper.go
+++ b/helper.go
@@ -7,13 +7,16 @@ import (
 
 func Ftoi(f float64) (i int64, dp int) {
 	fStr := fmt.Sprintf("%v", f)
-	s := strings.Split(fStr, ".")
-
-	// get decimal precision and calculate multiple.
 	multiple := 1
-	for i := 0; i < len(s[1]); i++ {
-		dp++
-		multiple = multiple * 10
+
+	if strings.Contains(fStr, ".") {
+		s := strings.Split(fStr, ".")
+
+		// get decimal precision and calculate multiple.
+		for i := 0; i < len(s[1]); i++ {
+			dp++
+			multiple = multiple * 10
+		}
 	}
 
 	i = int64(f * float64(multiple))


### PR DESCRIPTION
- Check for decimal place existing in string resulting from `fmt.Sprintf("%v", f)` before trying to split string on non-existent char.